### PR TITLE
Ensure that write calls do not fail

### DIFF
--- a/glad.c
+++ b/glad.c
@@ -468,10 +468,14 @@ void FlushOutput(conn_t*pstConn)
    if(pstConn->iOutLen>0)
    {
       /* Write the content of the output buffer to the socket descriptor */
-      write(pstConn->iSocket,pstConn->a_chOutBuf,pstConn->iOutLen);
+      ssize_t ret=write(pstConn->iSocket,pstConn->a_chOutBuf,pstConn->iOutLen);
 
-      /* Indicate that the output buffer is now empty */
-      pstConn->iOutLen=0;
+      if (ret >= pstConn->iOutLen) {
+         /* Indicate that the output buffer is now empty */
+         pstConn->iOutLen=0;
+      } else if (ret > 0) {
+         pstConn->iOutLen = pstConn->iOutLen - ret;
+      }
    }
 }
 


### PR DESCRIPTION
Until now, we were just assuming that FlushOutput calls were successful.

This commit now checks the write call return value, and only considers
flushed the number of actually written bytes.

In the future, we might consider add a return value to FlushOutput
calls, letting the caller know how successful was it.